### PR TITLE
distinguish between file, download and normal links and support piped links

### DIFF
--- a/wicked/link.py
+++ b/wicked/link.py
@@ -65,7 +65,18 @@ class BasicLink(object):
     @utils.clearbefore
     def load(self, links, chunk):
         self._links = links
-        self.chunk = chunk
+        if(chunk.lower().startswith('file:')):
+            parts = chunk[5:].strip().split('|')
+            self.type = 'Image'
+        elif(chunk.lower().startswith('download:')):
+            parts = chunk[9:].strip().split('|')
+            self.type = 'File'
+        else:
+            parts = chunk.strip().split('|')
+            self.type = 'Document'
+        
+        self.title = parts[0].strip()
+        self.chunk = parts[-1].strip()
 
 
 @adapter(IWickedEvent)

--- a/wicked/txtfilter.py
+++ b/wicked/txtfilter.py
@@ -67,7 +67,13 @@ class WickedFilter(TxtFilter):
     # optimization
     @utils.memoize
     def normalize(self, value):
-        return self._normalize(value)
+        if(value.lower().startswith('file:')):
+            parts = value[5:].strip().split('|')
+        elif(value.lower().startswith('download:')):
+            parts = value[9:].strip().split('|')
+        else:
+            parts = value.strip().split('|')
+        return self._normalize(parts[0].strip())
 
     @utils.memoizedproperty
     def encoding(self):

--- a/wicked/wicked_link.pt
+++ b/wicked/wicked_link.pt
@@ -1,31 +1,51 @@
 <tal:wicked_link>
   <span tal:condition="view/howmany" tal:omit-tag="">
-    <span tal:condition="not:view/multiple" tal:omit-tag=''>
+    <span tal:condition="not:view/multiple" tal:omit-tag=''> 
       <span tal:define="link view/singlelink" tal:omit-tag=''>
-    <span tal:attributes="id string:${view/section}-${link/uid}">
-      <a class="link-wiki"
-         tal:attributes="href link/url" tal:content="view/chunk">
-          CHUNK
-      </a>
-    </span>
+        <span tal:condition="python: view.type != 'Image'"
+              tal:attributes="id string:${view/section}-${link/uid}">
+          <a class="link-wiki"
+             tal:attributes="href link/url" tal:content="view/chunk">
+              CHUNK
+          </a>
+        </span>
+        <span tal:condition="python: view.type == 'Image'"
+              tal:attributes="id string:${view/section}-${link/uid}">
+          <a class="link-wiki"
+             tal:attributes="href link/url">
+              <img tal:attributes="src link/url" />
+          </a>
+        </span>
       </span>
     </span>
     <span tal:condition="view/multiple" tal:omit-tag="">
       <span tal:define="link view/singlelink" tal:omit-tag="">
-    <span metal:use-macro="here/wicked_link/macros/linkmenu">
-      the first link
-    </span>
+        <span metal:use-macro="here/wicked_link/macros/linkmenu">
+          the first link
+        </span>
       </span>
     </span>
   </span>
   <span tal:condition="not: view/howmany" tal:omit-tag=''>
-    <span tal:attributes="id string:${view/section}-${view/count}"
-      class="">
+    <span tal:condition="python: view.type != 'Image'"
+          tal:attributes="id string:${view/section}-${view/count}"
+          class="">
       <a class="link-wiki-add"
          title="Click to add a new page"
-     tal:attributes="href string:$here_url/@@wickedadd?Title=${view/chunk}&amp;section=${view/section}"
-     tal:define="here_url here/absolute_url">
-      <span tal:replace="view/chunk" >A CHUNK</span><sup>[+]</sup></a>
+         tal:attributes="href string:$here_url/@@wickedadd?Title=${view/title}&amp;section=${view/section}&amp;type_name=${view/type}"
+         tal:define="here_url here/absolute_url">
+        <span tal:replace="view/chunk" >A CHUNK</span><sup>[+]</sup>
+      </a>
+    </span>
+    <span tal:condition="python: view.type == 'Image'"
+          tal:attributes="id string:${view/section}-${view/count}"
+          class="">
+      <a class="link-wiki-add"
+         title="Click to add a new page"
+         tal:attributes="href string:$here_url/@@wickedadd?Title=${view/title}&amp;section=${view/section}&amp;type_name=${view/type}"
+         tal:define="here_url here/absolute_url">
+        <img tal:attributes="src view/title" /><sup>[+]</sup>
+      </a>
     </span>
   </span>
 </tal:wicked_link>


### PR DESCRIPTION
transforms [[file: image.png]] to an image and [[download: file.zip]] to a file link.
it also allows to create links like [[document-name|shown text]]

I'm not really familiar with wicked, so my code might need some polishing, but I think the general idea would be an improvement to wickeds functionality.
Any thoughts on this?
