### PR TITLE
invalidate cache when object has been moved or copied (fixes #2)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ Changelog
 1.1.12 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Invalidate cache when object has been moved or copied.
+  [domruf]
 
 
 1.1.11 (2014-04-15)

--- a/wicked/utils.py
+++ b/wicked/utils.py
@@ -19,7 +19,7 @@ def linkcache(func):
         # this could use some untangling
         # generic function?
         value = wfilter.cache.get(normalized)
-        if not value:
+        if not value or '/'.join(wfilter.context.getPhysicalPath()) != wfilter.cache.cache_store.id:
             value = func(wfilter, chunk, normalized)
             if value:
                 uid = value[0]['uid']


### PR DESCRIPTION
If the current path is different from the cache id, the cache should be invalidated.
